### PR TITLE
feat(#3): Firestore 포트폴리오 CRUD 연동

### DIFF
--- a/src/components/dashboard/category-allocation.tsx
+++ b/src/components/dashboard/category-allocation.tsx
@@ -45,7 +45,7 @@ export function CategoryAllocation({ categories }: CategoryAllocationProps) {
                   cx="50%"
                   cy="50%"
                   outerRadius={80}
-                  label={({ percentage }) => `${percentage.toFixed(1)}%`}
+                  label={(entry: any) => `${entry.percentage.toFixed(1)}%`}
                 >
                   {chartData.map((entry, index) => {
                     const categoryId = categories[index]?.id

--- a/src/components/portfolio/add-stock-dialog.tsx
+++ b/src/components/portfolio/add-stock-dialog.tsx
@@ -179,7 +179,10 @@ export function AddStockDialog({
           description: '포트폴리오가 수정되었습니다.',
         })
       } else {
-        await addMutation.mutateAsync(data)
+        await addMutation.mutateAsync({
+          ...data,
+          currentPrice: data.averageCost, // 초기 currentPrice는 averageCost와 동일하게 설정
+        })
         toast({
           title: '추가 완료',
           description: '포트폴리오에 종목이 추가되었습니다.',

--- a/src/lib/firebase/firestore.ts
+++ b/src/lib/firebase/firestore.ts
@@ -13,9 +13,11 @@ import {
   DocumentData,
   QueryDocumentSnapshot,
   FirestoreDataConverter,
+  setDoc,
 } from 'firebase/firestore'
 import { firestore } from './config'
 import { Portfolio, DailySnapshot } from '@/types/portfolio'
+import { SnapshotData } from '@/lib/storage/snapshots'
 
 // Portfolio Converter
 export const portfolioConverter: FirestoreDataConverter<Portfolio> = {
@@ -49,6 +51,10 @@ export const portfolioConverter: FirestoreDataConverter<Portfolio> = {
 
 // Portfolio CRUD
 export async function getPortfolios(userId: string): Promise<Portfolio[]> {
+  if (!firestore) {
+    throw new Error('Firestore가 초기화되지 않았습니다.')
+  }
+
   const q = query(
     collection(firestore, 'portfolios', userId, 'stocks'),
     orderBy('createdAt', 'desc')
@@ -62,6 +68,10 @@ export async function addPortfolio(
   userId: string,
   portfolio: Omit<Portfolio, 'id'>
 ): Promise<string> {
+  if (!firestore) {
+    throw new Error('Firestore가 초기화되지 않았습니다.')
+  }
+
   const ref = await addDoc(
     collection(firestore, 'portfolios', userId, 'stocks').withConverter(
       portfolioConverter
@@ -76,6 +86,10 @@ export async function updatePortfolio(
   portfolioId: string,
   data: Partial<Portfolio>
 ): Promise<void> {
+  if (!firestore) {
+    throw new Error('Firestore가 초기화되지 않았습니다.')
+  }
+
   const ref = doc(firestore, 'portfolios', userId, 'stocks', portfolioId)
   await updateDoc(ref, {
     ...data,
@@ -87,6 +101,90 @@ export async function deletePortfolio(
   userId: string,
   portfolioId: string
 ): Promise<void> {
+  if (!firestore) {
+    throw new Error('Firestore가 초기화되지 않았습니다.')
+  }
+
   const ref = doc(firestore, 'portfolios', userId, 'stocks', portfolioId)
   await deleteDoc(ref)
+}
+
+// Snapshot Converter
+export const snapshotConverter: FirestoreDataConverter<SnapshotData> = {
+  toFirestore: (snapshot: SnapshotData): DocumentData => ({
+    totalValue: snapshot.totalValue,
+    totalCost: snapshot.totalCost,
+    totalProfit: snapshot.totalProfit,
+    profitRate: snapshot.profitRate,
+    dailyProfit: snapshot.dailyProfit,
+    monthlyProfit: snapshot.monthlyProfit,
+    yearlyProfit: snapshot.yearlyProfit,
+  }),
+  fromFirestore: (snapshot: QueryDocumentSnapshot): SnapshotData => {
+    const data = snapshot.data()
+    return {
+      date: snapshot.id, // 문서 ID가 날짜 (YYYY-MM-DD)
+      totalValue: data.totalValue,
+      totalCost: data.totalCost,
+      totalProfit: data.totalProfit,
+      profitRate: data.profitRate,
+      dailyProfit: data.dailyProfit,
+      monthlyProfit: data.monthlyProfit,
+      yearlyProfit: data.yearlyProfit,
+    }
+  },
+}
+
+// Snapshot CRUD
+export async function getSnapshots(userId: string): Promise<SnapshotData[]> {
+  if (!firestore) {
+    throw new Error('Firestore가 초기화되지 않았습니다.')
+  }
+
+  const q = query(
+    collection(firestore, 'portfolios', userId, 'snapshots'),
+    orderBy('__name__', 'asc') // 문서 ID(날짜)로 정렬
+  ).withConverter(snapshotConverter)
+
+  const snapshot = await getDocs(q)
+  return snapshot.docs.map((doc) => doc.data())
+}
+
+export async function saveSnapshot(
+  userId: string,
+  snapshot: SnapshotData
+): Promise<void> {
+  if (!firestore) {
+    throw new Error('Firestore가 초기화되지 않았습니다.')
+  }
+
+  const ref = doc(
+    firestore,
+    'portfolios',
+    userId,
+    'snapshots',
+    snapshot.date
+  ).withConverter(snapshotConverter)
+
+  await setDoc(ref, snapshot)
+}
+
+export async function getSnapshotByDate(
+  userId: string,
+  date: string
+): Promise<SnapshotData | null> {
+  if (!firestore) {
+    throw new Error('Firestore가 초기화되지 않았습니다.')
+  }
+
+  const ref = doc(
+    firestore,
+    'portfolios',
+    userId,
+    'snapshots',
+    date
+  ).withConverter(snapshotConverter)
+
+  const snapshot = await getDoc(ref)
+  return snapshot.exists() ? snapshot.data() : null
 }


### PR DESCRIPTION
## 📌 관련 이슈
Closes #3

## 🎯 작업 내용
- [x] Firestore에 Snapshot CRUD 함수 추가
- [x] use-portfolio.ts를 Firestore로 전환
- [x] use-snapshots.ts를 Firestore로 전환
- [x] Firestore CRUD 함수에 null 체크 추가
- [x] 타입 에러 수정

## 📝 구현 방법

### 1. Firestore 컬렉션 구조
```
portfolios/
  {userId}/
    stocks/
      {stockId}: Portfolio 문서
    snapshots/
      {YYYY-MM-DD}: Snapshot 문서
```

### 2. Snapshot CRUD 함수
- `getSnapshots(userId)` - 사용자의 모든 스냅샷 조회
- `saveSnapshot(userId, snapshot)` - 스냅샷 저장/업데이트
- `getSnapshotByDate(userId, date)` - 특정 날짜 스냅샷 조회
- Snapshot Converter 추가하여 타입 안전성 확보

### 3. Hook 전환
- **use-portfolio.ts**: Firestore CRUD 함수 사용하도록 전환
- **use-snapshots.ts**: Firestore Snapshot 함수 사용하도록 전환
- 로그인 사용자는 Firestore, 비로그인은 로컬 스토리지 폴백

### 4. Null 체크 추가
- 모든 Firestore 함수에 `if (!firestore)` null 체크 추가
- 타입 에러 방지

## 🧪 테스트 체크리스트
- [x] 빌드 성공 (`npm run build`)
- [x] 타입 체크 통과 (Firestore 관련 에러 해결)
- [ ] 로그인 후 포트폴리오 CRUD 테스트 (수동)
- [ ] 로그인 후 스냅샷 저장 테스트 (수동)
- [ ] Firestore Console에서 데이터 확인 (수동)

## 💭 리뷰 노트
- 로컬 스토리지 폴백 기능 유지로 비로그인 사용자도 데모 가능
- Firestore 무료 플랜(Spark Plan) 범위 내에서 사용 가능
- 실시간 동기화는 추후 onSnapshot으로 개선 가능

🤖 Generated with [Claude Code](https://claude.com/claude-code)