### PR TITLE
feat(#5): 3개 카테고리 상세 페이지 구현

### DIFF
--- a/src/app/(dashboard)/categories/dividend/page.tsx
+++ b/src/app/(dashboard)/categories/dividend/page.tsx
@@ -1,0 +1,130 @@
+'use client'
+
+import { useState, useMemo } from 'react'
+import { CategoryHero } from '@/components/categories/category-hero'
+import { CategoryStockTable } from '@/components/categories/category-stock-table'
+import { GoalSettingDialog } from '@/components/categories/goal-setting-dialog'
+import { AddStockDialog } from '@/components/portfolio/add-stock-dialog'
+import { usePortfoliosWithProfit, useDeletePortfolio } from '@/lib/hooks/use-portfolio'
+import { useCategoryGoal } from '@/lib/hooks/use-category-goals'
+import { useAuth } from '@/lib/hooks/use-auth'
+import { useToast } from '@/hooks/use-toast'
+import { Portfolio } from '@/types/portfolio'
+
+const CATEGORY = {
+  id: 3,
+  name: '배당주',
+  icon: '💰',
+  description: '안정적인 배당 수익 중심 포트폴리오',
+}
+
+export default function DividendPage() {
+  const { user } = useAuth()
+  const { data: portfolios, isLoading } = usePortfoliosWithProfit()
+  const { data: goal } = useCategoryGoal(user?.uid || '', CATEGORY.id)
+  const deleteMutation = useDeletePortfolio()
+  const { toast } = useToast()
+
+  const [isGoalDialogOpen, setIsGoalDialogOpen] = useState(false)
+  const [isAddDialogOpen, setIsAddDialogOpen] = useState(false)
+  const [editingPortfolio, setEditingPortfolio] = useState<Portfolio | undefined>()
+
+  // 카테고리별 포트폴리오 필터링
+  const categoryPortfolios = useMemo(() => {
+    return portfolios.filter((p) => p.categoryId === CATEGORY.id)
+  }, [portfolios])
+
+  // 현재 카테고리 총액
+  const currentAmount = useMemo(() => {
+    return categoryPortfolios.reduce((sum, p) => sum + p.marketValue, 0)
+  }, [categoryPortfolios])
+
+  // 평균 수익률 계산
+  const averageReturn = useMemo(() => {
+    if (categoryPortfolios.length === 0) return 0
+    const totalReturn = categoryPortfolios.reduce((sum, p) => sum + p.profitRate, 0)
+    return totalReturn / categoryPortfolios.length
+  }, [categoryPortfolios])
+
+  const handleDelete = async (portfolio: Portfolio) => {
+    try {
+      await deleteMutation.mutateAsync(portfolio.id)
+      toast({
+        title: '삭제 완료',
+        description: '포트폴리오에서 종목이 삭제되었습니다.',
+      })
+    } catch (error: any) {
+      toast({
+        variant: 'destructive',
+        title: '삭제 실패',
+        description: error.message || '오류가 발생했습니다.',
+      })
+    }
+  }
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center h-[400px]">
+        <div className="text-center">
+          <div className="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent mx-auto mb-4" />
+          <p className="text-muted-foreground">데이터를 불러오는 중...</p>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* 히어로 섹션 */}
+      <CategoryHero
+        categoryName={CATEGORY.name}
+        categoryIcon={CATEGORY.icon}
+        categoryDescription={CATEGORY.description}
+        currentAmount={currentAmount}
+        targetAmount={goal?.targetAmount}
+        portfolioCount={categoryPortfolios.length}
+        averageReturn={averageReturn}
+        onSetGoal={() => setIsGoalDialogOpen(true)}
+      />
+
+      {/* 종목 테이블 */}
+      <CategoryStockTable
+        portfolios={categoryPortfolios}
+        categoryName={CATEGORY.name}
+        onAdd={() => {
+          setEditingPortfolio(undefined)
+          setIsAddDialogOpen(true)
+        }}
+        onEdit={(portfolio) => {
+          setEditingPortfolio(portfolio)
+          setIsAddDialogOpen(true)
+        }}
+        onDelete={handleDelete}
+      />
+
+      {/* 목표 설정 다이얼로그 */}
+      <GoalSettingDialog
+        open={isGoalDialogOpen}
+        onOpenChange={setIsGoalDialogOpen}
+        userId={user?.uid || ''}
+        categoryId={CATEGORY.id}
+        categoryName={CATEGORY.name}
+        categoryIcon={CATEGORY.icon}
+        currentGoal={goal?.targetAmount}
+      />
+
+      {/* 종목 추가/수정 다이얼로그 */}
+      <AddStockDialog
+        open={isAddDialogOpen}
+        onOpenChange={(open) => {
+          setIsAddDialogOpen(open)
+          if (!open) {
+            setEditingPortfolio(undefined)
+          }
+        }}
+        portfolio={editingPortfolio}
+        defaultCategoryId={CATEGORY.id}
+      />
+    </div>
+  )
+}

--- a/src/app/(dashboard)/categories/nasdaq100/page.tsx
+++ b/src/app/(dashboard)/categories/nasdaq100/page.tsx
@@ -1,0 +1,130 @@
+'use client'
+
+import { useState, useMemo } from 'react'
+import { CategoryHero } from '@/components/categories/category-hero'
+import { CategoryStockTable } from '@/components/categories/category-stock-table'
+import { GoalSettingDialog } from '@/components/categories/goal-setting-dialog'
+import { AddStockDialog } from '@/components/portfolio/add-stock-dialog'
+import { usePortfoliosWithProfit, useDeletePortfolio } from '@/lib/hooks/use-portfolio'
+import { useCategoryGoal } from '@/lib/hooks/use-category-goals'
+import { useAuth } from '@/lib/hooks/use-auth'
+import { useToast } from '@/hooks/use-toast'
+import { Portfolio } from '@/types/portfolio'
+
+const CATEGORY = {
+  id: 1,
+  name: '나스닥100',
+  icon: '📈',
+  description: '미국 대표 기술주 중심 포트폴리오',
+}
+
+export default function Nasdaq100Page() {
+  const { user } = useAuth()
+  const { data: portfolios, isLoading } = usePortfoliosWithProfit()
+  const { data: goal } = useCategoryGoal(user?.uid || '', CATEGORY.id)
+  const deleteMutation = useDeletePortfolio()
+  const { toast } = useToast()
+
+  const [isGoalDialogOpen, setIsGoalDialogOpen] = useState(false)
+  const [isAddDialogOpen, setIsAddDialogOpen] = useState(false)
+  const [editingPortfolio, setEditingPortfolio] = useState<Portfolio | undefined>()
+
+  // 카테고리별 포트폴리오 필터링
+  const categoryPortfolios = useMemo(() => {
+    return portfolios.filter((p) => p.categoryId === CATEGORY.id)
+  }, [portfolios])
+
+  // 현재 카테고리 총액
+  const currentAmount = useMemo(() => {
+    return categoryPortfolios.reduce((sum, p) => sum + p.marketValue, 0)
+  }, [categoryPortfolios])
+
+  // 평균 수익률 계산
+  const averageReturn = useMemo(() => {
+    if (categoryPortfolios.length === 0) return 0
+    const totalReturn = categoryPortfolios.reduce((sum, p) => sum + p.profitRate, 0)
+    return totalReturn / categoryPortfolios.length
+  }, [categoryPortfolios])
+
+  const handleDelete = async (portfolio: Portfolio) => {
+    try {
+      await deleteMutation.mutateAsync(portfolio.id)
+      toast({
+        title: '삭제 완료',
+        description: '포트폴리오에서 종목이 삭제되었습니다.',
+      })
+    } catch (error: any) {
+      toast({
+        variant: 'destructive',
+        title: '삭제 실패',
+        description: error.message || '오류가 발생했습니다.',
+      })
+    }
+  }
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center h-[400px]">
+        <div className="text-center">
+          <div className="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent mx-auto mb-4" />
+          <p className="text-muted-foreground">데이터를 불러오는 중...</p>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* 히어로 섹션 */}
+      <CategoryHero
+        categoryName={CATEGORY.name}
+        categoryIcon={CATEGORY.icon}
+        categoryDescription={CATEGORY.description}
+        currentAmount={currentAmount}
+        targetAmount={goal?.targetAmount}
+        portfolioCount={categoryPortfolios.length}
+        averageReturn={averageReturn}
+        onSetGoal={() => setIsGoalDialogOpen(true)}
+      />
+
+      {/* 종목 테이블 */}
+      <CategoryStockTable
+        portfolios={categoryPortfolios}
+        categoryName={CATEGORY.name}
+        onAdd={() => {
+          setEditingPortfolio(undefined)
+          setIsAddDialogOpen(true)
+        }}
+        onEdit={(portfolio) => {
+          setEditingPortfolio(portfolio)
+          setIsAddDialogOpen(true)
+        }}
+        onDelete={handleDelete}
+      />
+
+      {/* 목표 설정 다이얼로그 */}
+      <GoalSettingDialog
+        open={isGoalDialogOpen}
+        onOpenChange={setIsGoalDialogOpen}
+        userId={user?.uid || ''}
+        categoryId={CATEGORY.id}
+        categoryName={CATEGORY.name}
+        categoryIcon={CATEGORY.icon}
+        currentGoal={goal?.targetAmount}
+      />
+
+      {/* 종목 추가/수정 다이얼로그 */}
+      <AddStockDialog
+        open={isAddDialogOpen}
+        onOpenChange={(open) => {
+          setIsAddDialogOpen(open)
+          if (!open) {
+            setEditingPortfolio(undefined)
+          }
+        }}
+        portfolio={editingPortfolio}
+        defaultCategoryId={CATEGORY.id}
+      />
+    </div>
+  )
+}

--- a/src/app/(dashboard)/categories/sp500/page.tsx
+++ b/src/app/(dashboard)/categories/sp500/page.tsx
@@ -1,0 +1,130 @@
+'use client'
+
+import { useState, useMemo } from 'react'
+import { CategoryHero } from '@/components/categories/category-hero'
+import { CategoryStockTable } from '@/components/categories/category-stock-table'
+import { GoalSettingDialog } from '@/components/categories/goal-setting-dialog'
+import { AddStockDialog } from '@/components/portfolio/add-stock-dialog'
+import { usePortfoliosWithProfit, useDeletePortfolio } from '@/lib/hooks/use-portfolio'
+import { useCategoryGoal } from '@/lib/hooks/use-category-goals'
+import { useAuth } from '@/lib/hooks/use-auth'
+import { useToast } from '@/hooks/use-toast'
+import { Portfolio } from '@/types/portfolio'
+
+const CATEGORY = {
+  id: 2,
+  name: 'S&P 500',
+  icon: '📊',
+  description: '미국 대형주 지수 추종 포트폴리오',
+}
+
+export default function SP500Page() {
+  const { user } = useAuth()
+  const { data: portfolios, isLoading } = usePortfoliosWithProfit()
+  const { data: goal } = useCategoryGoal(user?.uid || '', CATEGORY.id)
+  const deleteMutation = useDeletePortfolio()
+  const { toast } = useToast()
+
+  const [isGoalDialogOpen, setIsGoalDialogOpen] = useState(false)
+  const [isAddDialogOpen, setIsAddDialogOpen] = useState(false)
+  const [editingPortfolio, setEditingPortfolio] = useState<Portfolio | undefined>()
+
+  // 카테고리별 포트폴리오 필터링
+  const categoryPortfolios = useMemo(() => {
+    return portfolios.filter((p) => p.categoryId === CATEGORY.id)
+  }, [portfolios])
+
+  // 현재 카테고리 총액
+  const currentAmount = useMemo(() => {
+    return categoryPortfolios.reduce((sum, p) => sum + p.marketValue, 0)
+  }, [categoryPortfolios])
+
+  // 평균 수익률 계산
+  const averageReturn = useMemo(() => {
+    if (categoryPortfolios.length === 0) return 0
+    const totalReturn = categoryPortfolios.reduce((sum, p) => sum + p.profitRate, 0)
+    return totalReturn / categoryPortfolios.length
+  }, [categoryPortfolios])
+
+  const handleDelete = async (portfolio: Portfolio) => {
+    try {
+      await deleteMutation.mutateAsync(portfolio.id)
+      toast({
+        title: '삭제 완료',
+        description: '포트폴리오에서 종목이 삭제되었습니다.',
+      })
+    } catch (error: any) {
+      toast({
+        variant: 'destructive',
+        title: '삭제 실패',
+        description: error.message || '오류가 발생했습니다.',
+      })
+    }
+  }
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center h-[400px]">
+        <div className="text-center">
+          <div className="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent mx-auto mb-4" />
+          <p className="text-muted-foreground">데이터를 불러오는 중...</p>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* 히어로 섹션 */}
+      <CategoryHero
+        categoryName={CATEGORY.name}
+        categoryIcon={CATEGORY.icon}
+        categoryDescription={CATEGORY.description}
+        currentAmount={currentAmount}
+        targetAmount={goal?.targetAmount}
+        portfolioCount={categoryPortfolios.length}
+        averageReturn={averageReturn}
+        onSetGoal={() => setIsGoalDialogOpen(true)}
+      />
+
+      {/* 종목 테이블 */}
+      <CategoryStockTable
+        portfolios={categoryPortfolios}
+        categoryName={CATEGORY.name}
+        onAdd={() => {
+          setEditingPortfolio(undefined)
+          setIsAddDialogOpen(true)
+        }}
+        onEdit={(portfolio) => {
+          setEditingPortfolio(portfolio)
+          setIsAddDialogOpen(true)
+        }}
+        onDelete={handleDelete}
+      />
+
+      {/* 목표 설정 다이얼로그 */}
+      <GoalSettingDialog
+        open={isGoalDialogOpen}
+        onOpenChange={setIsGoalDialogOpen}
+        userId={user?.uid || ''}
+        categoryId={CATEGORY.id}
+        categoryName={CATEGORY.name}
+        categoryIcon={CATEGORY.icon}
+        currentGoal={goal?.targetAmount}
+      />
+
+      {/* 종목 추가/수정 다이얼로그 */}
+      <AddStockDialog
+        open={isAddDialogOpen}
+        onOpenChange={(open) => {
+          setIsAddDialogOpen(open)
+          if (!open) {
+            setEditingPortfolio(undefined)
+          }
+        }}
+        portfolio={editingPortfolio}
+        defaultCategoryId={CATEGORY.id}
+      />
+    </div>
+  )
+}

--- a/src/components/categories/category-hero.tsx
+++ b/src/components/categories/category-hero.tsx
@@ -1,0 +1,159 @@
+'use client'
+
+import { Card, CardContent } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Progress } from '@/components/ui/progress'
+import { formatCurrency } from '@/lib/utils'
+import { Target, TrendingUp, Package } from 'lucide-react'
+import { motion } from 'framer-motion'
+
+interface CategoryHeroProps {
+  categoryName: string
+  categoryIcon: string
+  categoryDescription: string
+  currentAmount: number
+  targetAmount?: number
+  portfolioCount: number
+  averageReturn: number
+  onSetGoal: () => void
+}
+
+export function CategoryHero({
+  categoryName,
+  categoryIcon,
+  categoryDescription,
+  currentAmount,
+  targetAmount,
+  portfolioCount,
+  averageReturn,
+  onSetGoal,
+}: CategoryHeroProps) {
+  const progressPercentage = targetAmount
+    ? Math.min((currentAmount / targetAmount) * 100, 100)
+    : 0
+
+  const remainingAmount = targetAmount ? targetAmount - currentAmount : 0
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.5 }}
+    >
+      <Card className="relative overflow-hidden border-none bg-gradient-to-br from-blue-500/10 via-purple-500/10 to-pink-500/10 backdrop-blur-xl">
+        <CardContent className="p-8">
+          <div className="space-y-6">
+            {/* 헤더 */}
+            <div className="flex items-start justify-between">
+              <div className="space-y-2">
+                <div className="flex items-center gap-3">
+                  <span className="text-5xl">{categoryIcon}</span>
+                  <div>
+                    <h1 className="text-3xl font-bold">{categoryName}</h1>
+                    <p className="text-muted-foreground">{categoryDescription}</p>
+                  </div>
+                </div>
+              </div>
+              <Button onClick={onSetGoal} variant="outline" className="gap-2">
+                <Target className="h-4 w-4" />
+                {targetAmount ? '목표 수정' : '목표 설정'}
+              </Button>
+            </div>
+
+            {/* 목표 & 진행률 */}
+            {targetAmount ? (
+              <div className="space-y-4">
+                <div className="grid gap-4 md:grid-cols-3">
+                  <div className="space-y-1">
+                    <p className="text-sm text-muted-foreground">목표 금액</p>
+                    <p className="text-2xl font-bold">{formatCurrency(targetAmount)}</p>
+                  </div>
+                  <div className="space-y-1">
+                    <p className="text-sm text-muted-foreground">현재 금액</p>
+                    <p className="text-2xl font-bold">{formatCurrency(currentAmount)}</p>
+                  </div>
+                  <div className="space-y-1">
+                    <p className="text-sm text-muted-foreground">남은 금액</p>
+                    <p
+                      className={`text-2xl font-bold ${
+                        remainingAmount > 0 ? 'text-muted-foreground' : 'text-profit'
+                      }`}
+                    >
+                      {remainingAmount > 0
+                        ? formatCurrency(remainingAmount)
+                        : '목표 달성!'}
+                    </p>
+                  </div>
+                </div>
+
+                {/* 진행률 바 */}
+                <div className="space-y-2">
+                  <div className="flex items-center justify-between text-sm">
+                    <span className="text-muted-foreground">진행률</span>
+                    <span className="font-semibold">{progressPercentage.toFixed(1)}%</span>
+                  </div>
+                  <Progress value={progressPercentage} className="h-3" />
+                </div>
+
+                {/* 목표 달성 메시지 */}
+                {progressPercentage >= 100 && (
+                  <motion.div
+                    initial={{ scale: 0.9, opacity: 0 }}
+                    animate={{ scale: 1, opacity: 1 }}
+                    className="rounded-lg bg-profit/10 p-4 text-center"
+                  >
+                    <p className="text-lg font-semibold text-profit">
+                      🎉 축하합니다! 목표를 달성했습니다!
+                    </p>
+                  </motion.div>
+                )}
+              </div>
+            ) : (
+              <div className="rounded-lg border-2 border-dashed border-muted p-8 text-center">
+                <Target className="mx-auto mb-3 h-12 w-12 text-muted-foreground" />
+                <p className="mb-2 text-lg font-semibold">목표가 설정되지 않았습니다</p>
+                <p className="mb-4 text-sm text-muted-foreground">
+                  이 카테고리에 대한 목표 금액을 설정하고 진행률을 추적하세요.
+                </p>
+                <Button onClick={onSetGoal} className="gap-2">
+                  <Target className="h-4 w-4" />
+                  목표 설정하기
+                </Button>
+              </div>
+            )}
+
+            {/* 통계 정보 */}
+            <div className="grid gap-4 md:grid-cols-2">
+              <div className="flex items-center gap-3 rounded-lg bg-background/50 p-4">
+                <div className="flex h-12 w-12 items-center justify-center rounded-full bg-primary/10">
+                  <Package className="h-6 w-6 text-primary" />
+                </div>
+                <div>
+                  <p className="text-sm text-muted-foreground">보유 종목</p>
+                  <p className="text-2xl font-bold">{portfolioCount}개</p>
+                </div>
+              </div>
+
+              <div className="flex items-center gap-3 rounded-lg bg-background/50 p-4">
+                <div className="flex h-12 w-12 items-center justify-center rounded-full bg-profit/10">
+                  <TrendingUp className="h-6 w-6 text-profit" />
+                </div>
+                <div>
+                  <p className="text-sm text-muted-foreground">평균 수익률</p>
+                  <p
+                    className={`text-2xl font-bold ${
+                      averageReturn >= 0 ? 'text-profit' : 'text-loss'
+                    }`}
+                  >
+                    {averageReturn >= 0 ? '+' : ''}
+                    {averageReturn.toFixed(2)}%
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </motion.div>
+  )
+}

--- a/src/components/categories/category-stock-table.tsx
+++ b/src/components/categories/category-stock-table.tsx
@@ -1,0 +1,225 @@
+'use client'
+
+import { useState } from 'react'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
+import { Search, Plus, Trash2, TrendingUp, TrendingDown } from 'lucide-react'
+import { formatCurrency } from '@/lib/utils'
+import { PortfolioWithProfit } from '@/types/portfolio'
+
+interface CategoryStockTableProps {
+  portfolios: PortfolioWithProfit[]
+  categoryName: string
+  onAdd?: () => void
+  onEdit?: (portfolio: PortfolioWithProfit) => void
+  onDelete?: (portfolio: PortfolioWithProfit) => void
+}
+
+export function CategoryStockTable({
+  portfolios,
+  categoryName,
+  onAdd,
+  onEdit,
+  onDelete,
+}: CategoryStockTableProps) {
+  const [search, setSearch] = useState('')
+  const [sortBy, setSortBy] = useState<'ticker' | 'profit'>('ticker')
+  const [deletingPortfolio, setDeletingPortfolio] = useState<PortfolioWithProfit | null>(null)
+
+  const filtered = portfolios
+    .filter(
+      (p) =>
+        p.name.toLowerCase().includes(search.toLowerCase()) ||
+        p.ticker.toLowerCase().includes(search.toLowerCase())
+    )
+    .sort((a, b) => {
+      if (sortBy === 'profit') return b.profitRate - a.profitRate
+      return a.ticker.localeCompare(b.ticker)
+    })
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>보유 종목</CardTitle>
+        <CardDescription>{categoryName} 카테고리의 종목 목록</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="flex items-center justify-between gap-4">
+          <div className="relative flex-1 max-w-sm">
+            <Search className="absolute left-2 top-2.5 h-4 w-4 text-muted-foreground" />
+            <Input
+              placeholder="종목 검색..."
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              className="pl-8"
+            />
+          </div>
+          {onAdd && (
+            <Button onClick={onAdd}>
+              <Plus className="h-4 w-4 mr-2" />
+              종목 추가
+            </Button>
+          )}
+        </div>
+
+        {filtered.length > 0 ? (
+          <div className="rounded-md border">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead
+                    onClick={() => setSortBy('ticker')}
+                    className="cursor-pointer hover:bg-muted/50"
+                  >
+                    티커
+                  </TableHead>
+                  <TableHead>종목명</TableHead>
+                  <TableHead className="text-right">수량</TableHead>
+                  <TableHead className="text-right">평단가</TableHead>
+                  <TableHead className="text-right">현재가</TableHead>
+                  <TableHead className="text-right">평가액</TableHead>
+                  <TableHead className="text-right">수익금</TableHead>
+                  <TableHead
+                    className="text-right cursor-pointer hover:bg-muted/50"
+                    onClick={() => setSortBy('profit')}
+                  >
+                    수익률
+                  </TableHead>
+                  {onDelete && <TableHead className="w-[100px]">작업</TableHead>}
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {filtered.map((portfolio) => (
+                  <TableRow
+                    key={portfolio.id}
+                    className={`hover:bg-muted/50 ${onEdit ? 'cursor-pointer' : ''}`}
+                    onClick={() => onEdit?.(portfolio)}
+                  >
+                    <TableCell className="font-medium">{portfolio.ticker}</TableCell>
+                    <TableCell>{portfolio.name}</TableCell>
+                    <TableCell className="text-right">{portfolio.quantity}</TableCell>
+                    <TableCell className="text-right">
+                      {formatCurrency(portfolio.averageCost, portfolio.market)}
+                    </TableCell>
+                    <TableCell className="text-right">
+                      {formatCurrency(portfolio.currentPrice, portfolio.market)}
+                    </TableCell>
+                    <TableCell className="text-right font-semibold">
+                      {formatCurrency(portfolio.marketValue)}
+                    </TableCell>
+                    <TableCell
+                      className={`text-right font-semibold ${
+                        portfolio.profit >= 0 ? 'text-profit' : 'text-loss'
+                      }`}
+                    >
+                      <div className="flex items-center justify-end gap-1">
+                        {portfolio.profit >= 0 ? (
+                          <TrendingUp className="h-4 w-4" />
+                        ) : (
+                          <TrendingDown className="h-4 w-4" />
+                        )}
+                        {portfolio.profit >= 0 ? '+' : ''}
+                        {formatCurrency(portfolio.profit)}
+                      </div>
+                    </TableCell>
+                    <TableCell
+                      className={`text-right font-semibold ${
+                        portfolio.profitRate >= 0 ? 'text-profit' : 'text-loss'
+                      }`}
+                    >
+                      {portfolio.profitRate >= 0 ? '+' : ''}
+                      {portfolio.profitRate.toFixed(2)}%
+                    </TableCell>
+                    {onDelete && (
+                      <TableCell onClick={(e) => e.stopPropagation()}>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          onClick={() => setDeletingPortfolio(portfolio)}
+                          className="text-destructive hover:text-destructive"
+                        >
+                          <Trash2 className="h-4 w-4" />
+                        </Button>
+                      </TableCell>
+                    )}
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        ) : (
+          <div className="flex flex-col items-center justify-center rounded-lg border-2 border-dashed p-12 text-center">
+            <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-muted">
+              <Search className="h-6 w-6 text-muted-foreground" />
+            </div>
+            <h3 className="mt-4 text-lg font-semibold">
+              {search ? '검색 결과가 없습니다' : '보유 종목이 없습니다'}
+            </h3>
+            <p className="mt-2 text-sm text-muted-foreground">
+              {search
+                ? '다른 검색어로 시도해보세요'
+                : '이 카테고리에 종목을 추가하여 시작하세요'}
+            </p>
+            {onAdd && !search && (
+              <Button onClick={onAdd} className="mt-4">
+                <Plus className="h-4 w-4 mr-2" />
+                첫 번째 종목 추가하기
+              </Button>
+            )}
+          </div>
+        )}
+
+        {/* 삭제 확인 다이얼로그 */}
+        <AlertDialog
+          open={!!deletingPortfolio}
+          onOpenChange={(open) => !open && setDeletingPortfolio(null)}
+        >
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>종목 삭제</AlertDialogTitle>
+              <AlertDialogDescription>
+                정말로 {deletingPortfolio?.name} ({deletingPortfolio?.ticker})을(를)
+                삭제하시겠습니까?
+                <br />
+                이 작업은 되돌릴 수 없습니다.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel>취소</AlertDialogCancel>
+              <AlertDialogAction
+                onClick={() => {
+                  if (deletingPortfolio && onDelete) {
+                    onDelete(deletingPortfolio)
+                    setDeletingPortfolio(null)
+                  }
+                }}
+                className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              >
+                삭제
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/components/categories/goal-setting-dialog.tsx
+++ b/src/components/categories/goal-setting-dialog.tsx
@@ -1,0 +1,158 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { useToast } from '@/hooks/use-toast'
+import { useCreateCategoryGoal } from '@/lib/hooks/use-category-goals'
+import { formatCurrency } from '@/lib/utils'
+
+interface GoalSettingDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  userId: string
+  categoryId: number
+  categoryName: string
+  categoryIcon: string
+  currentGoal?: number
+}
+
+export function GoalSettingDialog({
+  open,
+  onOpenChange,
+  userId,
+  categoryId,
+  categoryName,
+  categoryIcon,
+  currentGoal,
+}: GoalSettingDialogProps) {
+  const [targetAmount, setTargetAmount] = useState('')
+  const { toast } = useToast()
+  const createMutation = useCreateCategoryGoal()
+
+  useEffect(() => {
+    if (open && currentGoal) {
+      setTargetAmount(currentGoal.toString())
+    } else if (!open) {
+      setTargetAmount('')
+    }
+  }, [open, currentGoal])
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+
+    const amount = parseFloat(targetAmount)
+    if (isNaN(amount) || amount <= 0) {
+      toast({
+        variant: 'destructive',
+        title: '입력 오류',
+        description: '올바른 금액을 입력해주세요.',
+      })
+      return
+    }
+
+    try {
+      await createMutation.mutateAsync({
+        userId,
+        categoryId,
+        targetAmount: amount,
+      })
+
+      toast({
+        title: '목표 설정 완료',
+        description: `${categoryName} 목표가 ${formatCurrency(amount)}(으)로 설정되었습니다.`,
+      })
+
+      onOpenChange(false)
+    } catch (error: any) {
+      toast({
+        variant: 'destructive',
+        title: '목표 설정 실패',
+        description: error.message || '오류가 발생했습니다.',
+      })
+    }
+  }
+
+  const handleAmountChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value.replace(/[^0-9]/g, '')
+    setTargetAmount(value)
+  }
+
+  const presetAmounts = [10000000, 30000000, 50000000, 100000000]
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[500px]">
+        <form onSubmit={handleSubmit}>
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">
+              <span className="text-2xl">{categoryIcon}</span>
+              <span>{categoryName} 목표 설정</span>
+            </DialogTitle>
+            <DialogDescription>
+              이 카테고리에 대한 목표 금액을 설정하세요.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-4 py-4">
+            <div className="space-y-2">
+              <Label htmlFor="targetAmount">목표 금액 (원)</Label>
+              <Input
+                id="targetAmount"
+                type="text"
+                placeholder="50000000"
+                value={targetAmount}
+                onChange={handleAmountChange}
+                className="text-lg"
+              />
+              {targetAmount && (
+                <p className="text-sm text-muted-foreground">
+                  {formatCurrency(parseFloat(targetAmount) || 0)}
+                </p>
+              )}
+            </div>
+
+            <div className="space-y-2">
+              <Label>빠른 선택</Label>
+              <div className="grid grid-cols-2 gap-2">
+                {presetAmounts.map((amount) => (
+                  <Button
+                    key={amount}
+                    type="button"
+                    variant="outline"
+                    onClick={() => setTargetAmount(amount.toString())}
+                    className="justify-start"
+                  >
+                    {formatCurrency(amount)}
+                  </Button>
+                ))}
+              </div>
+            </div>
+          </div>
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+            >
+              취소
+            </Button>
+            <Button type="submit" disabled={createMutation.isPending}>
+              {createMutation.isPending ? '저장 중...' : '목표 설정'}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/components/layouts/sidebar.tsx
+++ b/src/components/layouts/sidebar.tsx
@@ -17,10 +17,26 @@ import {
 import { Button } from '@/components/ui/button'
 import { useAuth } from '@/lib/hooks/use-auth'
 
-const navigation = [
+type NavigationItem = {
+  name: string
+  href: string
+  icon: any
+  subItems?: Array<{ name: string; href: string }>
+}
+
+const navigation: NavigationItem[] = [
   { name: '대시보드', href: '/dashboard', icon: LayoutDashboard },
   { name: '포트폴리오', href: '/portfolio', icon: Wallet },
-  { name: '카테고리', href: '/categories', icon: PieChart },
+  {
+    name: '카테고리',
+    href: '/categories',
+    icon: PieChart,
+    subItems: [
+      { name: '📈 나스닥100', href: '/categories/nasdaq100' },
+      { name: '📊 S&P 500', href: '/categories/sp500' },
+      { name: '💰 배당주', href: '/categories/dividend' },
+    ],
+  },
   { name: '수익 추이 분석', href: '/analytics', icon: BarChart3 },
   { name: '리밸런싱', href: '/rebalancing', icon: BarChart3 },
   { name: '월간 리포트', href: '/reports', icon: Calendar },
@@ -51,19 +67,40 @@ export function Sidebar() {
           const isActive = pathname === item.href || pathname?.startsWith(item.href + '/')
 
           return (
-            <Link
-              key={item.name}
-              href={item.href}
-              className={cn(
-                'flex items-center space-x-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors',
-                isActive
-                  ? 'bg-primary text-primary-foreground'
-                  : 'text-muted-foreground hover:bg-accent hover:text-accent-foreground'
+            <div key={item.name}>
+              <Link
+                href={item.href}
+                className={cn(
+                  'flex items-center space-x-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors',
+                  isActive
+                    ? 'bg-primary text-primary-foreground'
+                    : 'text-muted-foreground hover:bg-accent hover:text-accent-foreground'
+                )}
+              >
+                <Icon className="h-5 w-5" />
+                <span>{item.name}</span>
+              </Link>
+
+              {/* 서브 메뉴 */}
+              {item.subItems && isActive && (
+                <div className="ml-8 mt-1 space-y-1">
+                  {item.subItems.map((subItem) => (
+                    <Link
+                      key={subItem.name}
+                      href={subItem.href}
+                      className={cn(
+                        'block rounded-lg px-3 py-1.5 text-sm transition-colors',
+                        pathname === subItem.href
+                          ? 'bg-primary/10 text-primary font-medium'
+                          : 'text-muted-foreground hover:bg-accent hover:text-accent-foreground'
+                      )}
+                    >
+                      {subItem.name}
+                    </Link>
+                  ))}
+                </div>
               )}
-            >
-              <Icon className="h-5 w-5" />
-              <span>{item.name}</span>
-            </Link>
+            </div>
           )
         })}
       </nav>

--- a/src/components/portfolio/add-stock-dialog.tsx
+++ b/src/components/portfolio/add-stock-dialog.tsx
@@ -43,12 +43,14 @@ interface AddStockDialogProps {
   open: boolean
   onOpenChange: (open: boolean) => void
   portfolio?: Portfolio
+  defaultCategoryId?: number
 }
 
 export function AddStockDialog({
   open,
   onOpenChange,
   portfolio,
+  defaultCategoryId,
 }: AddStockDialogProps) {
   const { toast } = useToast()
   const addMutation = useAddPortfolio()
@@ -97,10 +99,10 @@ export function AddStockDialog({
         quantity: 1,
         averageCost: 0,
         market: 'US',
-        categoryId: undefined,
+        categoryId: defaultCategoryId,
       })
     }
-  }, [portfolio, reset])
+  }, [portfolio, defaultCategoryId, reset])
 
   const handleSearch = async () => {
     if (!searchQuery.trim()) return

--- a/src/lib/firebase/category-goals.ts
+++ b/src/lib/firebase/category-goals.ts
@@ -1,0 +1,143 @@
+import {
+  collection,
+  doc,
+  getDocs,
+  getDoc,
+  addDoc,
+  updateDoc,
+  deleteDoc,
+  query,
+  where,
+  orderBy,
+  Timestamp,
+} from 'firebase/firestore'
+import { firestore as db } from './config'
+import { CategoryGoal } from '@/types/portfolio'
+
+const COLLECTION_NAME = 'categoryGoals'
+
+// Firestore 데이터를 CategoryGoal로 변환
+function convertToCategoryGoal(id: string, data: any): CategoryGoal {
+  return {
+    id,
+    userId: data.userId,
+    categoryId: data.categoryId,
+    targetAmount: data.targetAmount,
+    createdAt: data.createdAt?.toDate() || new Date(),
+    updatedAt: data.updatedAt?.toDate() || new Date(),
+  }
+}
+
+// 사용자의 모든 카테고리 목표 조회
+export async function getCategoryGoals(userId: string): Promise<CategoryGoal[]> {
+  if (!db) return []
+
+  try {
+    const q = query(
+      collection(db, COLLECTION_NAME),
+      where('userId', '==', userId),
+      orderBy('categoryId', 'asc')
+    )
+    const snapshot = await getDocs(q)
+    return snapshot.docs.map((doc) => convertToCategoryGoal(doc.id, doc.data()))
+  } catch (error) {
+    console.error('Error getting category goals:', error)
+    return []
+  }
+}
+
+// 특정 카테고리 목표 조회
+export async function getCategoryGoal(
+  userId: string,
+  categoryId: number
+): Promise<CategoryGoal | null> {
+  if (!db) return null
+
+  try {
+    const q = query(
+      collection(db, COLLECTION_NAME),
+      where('userId', '==', userId),
+      where('categoryId', '==', categoryId)
+    )
+    const snapshot = await getDocs(q)
+
+    if (snapshot.empty) return null
+
+    const doc = snapshot.docs[0]
+    return convertToCategoryGoal(doc.id, doc.data())
+  } catch (error) {
+    console.error('Error getting category goal:', error)
+    return null
+  }
+}
+
+// 카테고리 목표 생성
+export async function createCategoryGoal(
+  data: Omit<CategoryGoal, 'id' | 'createdAt' | 'updatedAt'>
+): Promise<CategoryGoal> {
+  if (!db) throw new Error('Firebase is not configured')
+
+  try {
+    // 기존 목표가 있는지 확인
+    const existingGoal = await getCategoryGoal(data.userId, data.categoryId)
+    if (existingGoal) {
+      // 이미 존재하면 업데이트
+      return (await updateCategoryGoal(existingGoal.id, {
+        targetAmount: data.targetAmount,
+      })) as CategoryGoal
+    }
+
+    const now = Timestamp.now()
+    const docRef = await addDoc(collection(db, COLLECTION_NAME), {
+      ...data,
+      createdAt: now,
+      updatedAt: now,
+    })
+
+    return {
+      id: docRef.id,
+      ...data,
+      createdAt: now.toDate(),
+      updatedAt: now.toDate(),
+    }
+  } catch (error) {
+    console.error('Error creating category goal:', error)
+    throw error
+  }
+}
+
+// 카테고리 목표 수정
+export async function updateCategoryGoal(
+  id: string,
+  data: Partial<CategoryGoal>
+): Promise<CategoryGoal | null> {
+  if (!db) throw new Error('Firebase is not configured')
+
+  try {
+    const docRef = doc(db, COLLECTION_NAME, id)
+    await updateDoc(docRef, {
+      ...data,
+      updatedAt: Timestamp.now(),
+    })
+
+    const updatedDoc = await getDoc(docRef)
+    if (!updatedDoc.exists()) return null
+
+    return convertToCategoryGoal(updatedDoc.id, updatedDoc.data())
+  } catch (error) {
+    console.error('Error updating category goal:', error)
+    throw error
+  }
+}
+
+// 카테고리 목표 삭제
+export async function deleteCategoryGoal(id: string): Promise<void> {
+  if (!db) throw new Error('Firebase is not configured')
+
+  try {
+    await deleteDoc(doc(db, COLLECTION_NAME, id))
+  } catch (error) {
+    console.error('Error deleting category goal:', error)
+    throw error
+  }
+}

--- a/src/lib/hooks/use-category-goals.ts
+++ b/src/lib/hooks/use-category-goals.ts
@@ -1,0 +1,75 @@
+'use client'
+
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { CategoryGoal } from '@/types/portfolio'
+import {
+  getCategoryGoals,
+  getCategoryGoal,
+  createCategoryGoal,
+  updateCategoryGoal,
+  deleteCategoryGoal,
+} from '@/lib/firebase/category-goals'
+
+// 카테고리 목표 목록 조회
+export function useCategoryGoals(userId?: string) {
+  return useQuery({
+    queryKey: ['categoryGoals', userId],
+    queryFn: () => getCategoryGoals(userId || ''),
+    enabled: !!userId,
+  })
+}
+
+// 특정 카테고리 목표 조회
+export function useCategoryGoal(userId: string, categoryId: number) {
+  return useQuery({
+    queryKey: ['categoryGoal', userId, categoryId],
+    queryFn: () => getCategoryGoal(userId, categoryId),
+    enabled: !!userId && !!categoryId,
+  })
+}
+
+// 카테고리 목표 생성
+export function useCreateCategoryGoal() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: createCategoryGoal,
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({ queryKey: ['categoryGoals', variables.userId] })
+      queryClient.invalidateQueries({
+        queryKey: ['categoryGoal', variables.userId, variables.categoryId],
+      })
+    },
+  })
+}
+
+// 카테고리 목표 수정
+export function useUpdateCategoryGoal() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: ({ id, data }: { id: string; data: Partial<CategoryGoal> }) =>
+      updateCategoryGoal(id, data),
+    onSuccess: (goal) => {
+      if (goal) {
+        queryClient.invalidateQueries({ queryKey: ['categoryGoals', goal.userId] })
+        queryClient.invalidateQueries({
+          queryKey: ['categoryGoal', goal.userId, goal.categoryId],
+        })
+      }
+    },
+  })
+}
+
+// 카테고리 목표 삭제
+export function useDeleteCategoryGoal() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: deleteCategoryGoal,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['categoryGoals'] })
+      queryClient.invalidateQueries({ queryKey: ['categoryGoal'] })
+    },
+  })
+}

--- a/src/types/portfolio.ts
+++ b/src/types/portfolio.ts
@@ -34,3 +34,12 @@ export interface DailySnapshot {
   dailyProfit: number
   createdAt: Date
 }
+
+export interface CategoryGoal {
+  id: string
+  userId: string
+  categoryId: number
+  targetAmount: number // 목표 금액 (원화)
+  createdAt: Date
+  updatedAt: Date
+}


### PR DESCRIPTION
## 📌 관련 이슈
Closes #5

## 🎯 작업 내용
- [x] 나스닥100, S&P 500, 배당주 전용 페이지 생성
- [x] 카테고리 히어로 섹션 구현 (목표 금액, 진행률, 통계)
- [x] 목표 설정 다이얼로그 구현 (빠른 선택 포함)
- [x] 카테고리별 종목 테이블 구현 (검색, 정렬, CRUD)
- [x] Firestore 목표 데이터 연동 (CRUD 훅)
- [x] 사이드바에 카테고리 하위 메뉴 추가
- [x] AddStockDialog에 defaultCategoryId 지원

## 🧪 테스트 체크리스트
- [x] 빌드 성공
- [x] 타입 체크 통과
- [x] 3개 카테고리 페이지 모두 정상 작동
- [x] 목표 설정 및 저장 기능
- [x] 진행률 정확히 계산
- [x] 카테고리별 종목 필터링
- [x] 반응형 디자인

## 📝 구현 상세

### 1. 카테고리 페이지 구조
- `/categories/nasdaq100` - 나스닥100 페이지
- `/categories/sp500` - S&P 500 페이지
- `/categories/dividend` - 배당주 페이지

### 2. 주요 컴포넌트
- `CategoryHero` - 히어로 섹션 (목표, 진행률, 통계)
- `GoalSettingDialog` - 목표 설정 다이얼로그
- `CategoryStockTable` - 카테고리별 종목 테이블

### 3. Firestore 연동
- `CategoryGoal` 타입 정의
- `category-goals.ts` - Firestore CRUD 함수
- `use-category-goals.ts` - React Query 훅

### 4. 사이드바 업데이트
- 카테고리 하위 메뉴 추가 (3개 카테고리 링크)
- 현재 선택된 카테고리 하이라이트

🤖 Generated with [Claude Code](https://claude.com/claude-code)